### PR TITLE
MapThemes and Styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,20 @@ Set the names of the map themes that should be considered as a list:
 export_settings.mapthemes = ["Robot Theme", "French Theme"]
 ```
 
+#### Custom Project Variables Settings
+
+Set the keys of custom variables that should be considered as a list:
+```py
+export_settings.custom_variables = ["First Variable", "Another Variable", "Variable with Structure"]
+```
+
+#### Print Layout Settings
+
+Set the names of layouts that should be considered (exported as template files) as a list:
+```py
+export_settings.custom_variables = ["Layout One", "Layout Two"]
+```
+
 ### Generate the Files for a `ProjectTopping` containing `ExportSetting`
 When parsing the QgsProject we need to pass the `ExportSettings`:
 ```py
@@ -382,6 +396,14 @@ class ToppingType(Enum):
 #### Map Themes Settings
 
 The export setting of the map themes is a simple list of maptheme names: `mapthemes = []`
+
+#### Custom Project Variables:
+
+The export setting of the custom variables is simple list of the keys stored in `custom_variables = []`.
+
+#### Layouts:
+
+The export setting of the print layouts is simple list of the layout names stored in `layouts = []`.
 
 ## Infos for Devs
 

--- a/README.md
+++ b/README.md
@@ -163,14 +163,14 @@ export_settings.mapthemes = ["Robot Theme", "French Theme"]
 
 Set the keys of custom variables that should be considered as a list:
 ```py
-export_settings.variables = ["First Variable", "Another Variable", "Variable with Structure"]
+export_settings.variables = ["First Variable", "Variable with Structure"]
 ```
 
 #### Print Layout Settings
 
 Set the names of layouts that should be considered (exported as template files) as a list:
 ```py
-export_settings.variables = ["Layout One", "Layout Two"]
+export_settings.variables = ["Layout One", "Layout Three"]
 ```
 
 ### Generate the Files for a `ProjectTopping` containing `ExportSetting`
@@ -275,6 +275,17 @@ mapthemes:
       expanded: false
 
 layerorder: []
+
+variables:
+  "First Variable": "This is a test value."
+  "Variable with Structure": ["Not", "The", "Normal", 815, "Case"]
+
+layouts:
+  "Layout One":
+    templatefile: "../layouttemplate/layout_one.qpt"
+  "Layout Three":
+    templatefile: "../layouttemplate/layout_three.qpt"
+
 ```
 
 ## Most important functions

--- a/README.md
+++ b/README.md
@@ -193,6 +193,9 @@ repo
         ├── freddys_qgis_project_street.qml
         ├── freddys_qgis_project_street_french.qml
         └── freddys_qgis_project_street_robot.qml
+    └── layouttemplate
+        ├── freddys_qgis_project_layout_one.qpt
+        └── freddys_qgis_project_layout_three.qpt
 ```
 
 And the YAML looks like this:
@@ -282,9 +285,9 @@ variables:
 
 layouts:
   "Layout One":
-    templatefile: "../layouttemplate/layout_one.qpt"
+    templatefile: "../layouttemplate/freddys_qgis_project_layout_one.qpt"
   "Layout Three":
-    templatefile: "../layouttemplate/layout_three.qpt"
+    templatefile: "../layouttemplate/freddys_qgis_project_layout_three.qpt"
 
 ```
 
@@ -295,8 +298,8 @@ A project configuration resulting in a YAML file that contains:
 - layerorder
 - layer styles
 - map themes
-- project variables (future)
-- print layout (future)
+- project variables
+- print layouts
 
 QML style files, QLR layer definition files and the source of a layer can be linked in the YAML file and are exported to the specific folders.
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ export_settings.mapthemes = ["Robot Theme", "French Theme"]
 
 Set the keys of custom variables that should be considered as a list:
 ```py
-export_settings.variables = ["First Variable", "Variable with Structure"]
+export_settings.variables = ["first_variable", "Another_Variable"]
 ```
 
 #### Print Layout Settings
@@ -277,8 +277,8 @@ mapthemes:
 layerorder: []
 
 variables:
-  "First Variable": "This is a test value."
-  "Variable with Structure": ["Not", "The", "Normal", 815, "Case"]
+  "first_variable": "This is a test value."
+  "Another_Variable": "2"
 
 layouts:
   "Layout One":

--- a/README.md
+++ b/README.md
@@ -163,14 +163,14 @@ export_settings.mapthemes = ["Robot Theme", "French Theme"]
 
 Set the keys of custom variables that should be considered as a list:
 ```py
-export_settings.custom_variables = ["First Variable", "Another Variable", "Variable with Structure"]
+export_settings.variables = ["First Variable", "Another Variable", "Variable with Structure"]
 ```
 
 #### Print Layout Settings
 
 Set the names of layouts that should be considered (exported as template files) as a list:
 ```py
-export_settings.custom_variables = ["Layout One", "Layout Two"]
+export_settings.variables = ["Layout One", "Layout Two"]
 ```
 
 ### Generate the Files for a `ProjectTopping` containing `ExportSetting`
@@ -399,7 +399,7 @@ The export setting of the map themes is a simple list of maptheme names: `mapthe
 
 #### Custom Project Variables:
 
-The export setting of the custom variables is simple list of the keys stored in `custom_variables = []`.
+The export setting of the custom variables is simple list of the keys stored in `variables = []`.
 
 #### Layouts:
 

--- a/tests/test_toppingmaker.py
+++ b/tests/test_toppingmaker.py
@@ -171,10 +171,14 @@ class ToppingMakerTest(unittest.TestCase):
 
         countchecked = 0
 
-        # there should be 13 toppingfiles: one project topping, and 2 x 6 toppingfiles of the layers (since the layers are multiple times in the tree)
-        assert len(target.toppingfileinfo_list) == 13
+        # there should be 13 toppingfiles:
+        # - one project topping
+        # - 2 x 3 qlr files (two times since the layers are multiple times in the tree)
+        # - 2 x 6 qml files (one layers with 3 styles, one layer with 2 styles and one layer with one style - and two times since the layers are multiple times in the tree)
+        assert len(target.toppingfileinfo_list) == 19
 
         for toppingfileinfo in target.toppingfileinfo_list:
+            print(toppingfileinfo["path"])
             assert "path" in toppingfileinfo
             assert "type" in toppingfileinfo
 
@@ -185,7 +189,22 @@ class ToppingMakerTest(unittest.TestCase):
                 countchecked += 1
             if (
                 toppingfileinfo["path"]
+                == "freddys_projects/this_specific_project/layerstyle/freddys_layer_one_french_1.qml"
+            ):
+                countchecked += 1
+            if (
+                toppingfileinfo["path"]
+                == "freddys_projects/this_specific_project/layerstyle/freddys_layer_one_robot_1.qml"
+            ):
+                countchecked += 1
+            if (
+                toppingfileinfo["path"]
                 == "freddys_projects/this_specific_project/layerstyle/freddys_layer_three.qml"
+            ):
+                countchecked += 1
+            if (
+                toppingfileinfo["path"]
+                == "freddys_projects/this_specific_project/layerstyle/freddys_layer_three_french_3.qml"
             ):
                 countchecked += 1
             if (
@@ -209,7 +228,7 @@ class ToppingMakerTest(unittest.TestCase):
             ):
                 countchecked += 1
 
-        assert countchecked == 12
+        assert countchecked == 18
 
     def test_custom_path_resolver(self):
         # load QGIS project into structure

--- a/tests/test_toppingmaker.py
+++ b/tests/test_toppingmaker.py
@@ -142,7 +142,9 @@ class ToppingMakerTest(unittest.TestCase):
 
         # check variables
         variables = project_topping.variables
+        # Anyway in practice no spaces should be used to be able to access them in the expressions like @first_variable
         assert variables.get("First Variable") == "This is a test value."
+        # QGIS is currently (3.29) not able to store structures in the project file. Still...
         assert variables.get("Variable with Structure") == [
             "Not",
             "The",

--- a/tests/test_toppingmaker.py
+++ b/tests/test_toppingmaker.py
@@ -141,9 +141,9 @@ class ToppingMakerTest(unittest.TestCase):
         assert "Big Group" not in mapthemes["French Theme"]
 
         # check variables
-        custom_variables = project_topping.custom_variables
-        assert custom_variables.get("First Variable") == "This is a test value."
-        assert custom_variables.get("Variable with Structure") == [
+        variables = project_topping.variables
+        assert variables.get("First Variable") == "This is a test value."
+        assert variables.get("Variable with Structure") == [
             "Not",
             "The",
             "Normal",
@@ -151,7 +151,7 @@ class ToppingMakerTest(unittest.TestCase):
             "Case",
         ]
         # "Another Variable" is in the project but not in the export_settings
-        assert "Another Variable" not in custom_variables
+        assert "Another Variable" not in variables
 
         # check layouts
         layouts = project_topping.layouts
@@ -641,12 +641,6 @@ class ToppingMakerTest(unittest.TestCase):
         allofemgroup.addLayer(l4)
         allofemgroup.addLayer(l5)
 
-        # create a map theme from the current state
-        # layertree_root = project.layerTreeRoot()
-        # layertree_model = QgsLayerTreeModel(layertree_root)
-        # map_theme_record = QgsMapThemeCollection.createThemeFromCurrentState(layertree_root,layertree_model)
-        # project.mapThemeCollection().insert("General Theme", map_theme_record)
-
         # create robot map theme
         # with styles and layer one unchecked
         map_theme_record = QgsMapThemeCollection.MapThemeRecord()
@@ -774,7 +768,7 @@ class ToppingMakerTest(unittest.TestCase):
         export_settings.mapthemes = ["French Theme", "Robot Theme"]
 
         # define the custom variables to export
-        export_settings.custom_variables = ["First Variable", "Variable with Structure"]
+        export_settings.variables = ["First Variable", "Variable with Structure"]
 
         # define the layouts to export
         export_settings.layouts = ["Layout One", "Layout Three"]

--- a/tests/test_toppingmaker.py
+++ b/tests/test_toppingmaker.py
@@ -467,7 +467,7 @@ class ToppingMakerTest(unittest.TestCase):
         assert len(target.toppingfileinfo_list) == 21
 
         for toppingfileinfo in target.toppingfileinfo_list:
-            print(toppingfileinfo["path"])
+            self.print_info(toppingfileinfo["path"])
             assert "path" in toppingfileinfo
             assert "type" in toppingfileinfo
 
@@ -775,12 +775,16 @@ class ToppingMakerTest(unittest.TestCase):
         # define the layouts to export
         export_settings.layouts = ["Layout One", "Layout Three"]
 
-        print(f" Layer to style export: {export_settings.qmlstyle_setting_nodes}")
-        print(
+        self.print_info(
+            f" Layer to style export: {export_settings.qmlstyle_setting_nodes}"
+        )
+        self.print_info(
             f" Layer to definition export: {export_settings.definition_setting_nodes}"
         )
-        print(f" Layer to source export: {export_settings.source_setting_nodes}")
-        print(f" Map Themes to export: {export_settings.mapthemes}")
+        self.print_info(
+            f" Layer to source export: {export_settings.source_setting_nodes}"
+        )
+        self.print_info(f" Map Themes to export: {export_settings.mapthemes}")
         return project, export_settings
 
     def print_info(self, text):

--- a/tests/test_toppingmaker.py
+++ b/tests/test_toppingmaker.py
@@ -24,10 +24,18 @@ import os
 import tempfile
 
 import yaml
-from qgis.core import QgsMapThemeCollection, QgsProject, QgsVectorLayer
-from qgis.testing import unittest
+from qgis.core import (
+    QgsExpressionContextUtils,
+    QgsMapThemeCollection,
+    QgsPrintLayout,
+    QgsProject,
+    QgsVectorLayer,
+)
+from qgis.testing import start_app, unittest
 
 from toppingmaker import ExportSettings, ProjectTopping, Target
+
+start_app()
 
 
 class ToppingMakerTest(unittest.TestCase):
@@ -103,7 +111,7 @@ class ToppingMakerTest(unittest.TestCase):
 
     def test_parse_project_with_mapthemes(self):
         """
-        Parse it without export settings defining map themes.
+        Parse it with export settings defining map themes, variables and layouts
         """
         project, export_settings = self._make_project_and_export_settings()
 
@@ -132,7 +140,31 @@ class ToppingMakerTest(unittest.TestCase):
         assert "Small Group" not in mapthemes["French Theme"]
         assert "Big Group" not in mapthemes["French Theme"]
 
+        # check variables
+        custom_variables = project_topping.custom_variables
+        assert custom_variables.get("First Variable") == "This is a test value."
+        assert custom_variables.get("Variable with Structure") == [
+            "Not",
+            "The",
+            "Normal",
+            815,
+            "Case",
+        ]
+        # "Another Variable" is in the project but not in the export_settings
+        assert "Another Variable" not in custom_variables
+
+        # check layouts
+        layouts = project_topping.layouts
+        assert layouts.get("Layout One")
+        assert layouts.get("Layout Three")
+        # "Layout Two" is in the project but not in the export_settings
+        assert "Layout Two" not in layouts
+
     def test_generate_files(self):
+        """
+        Generate projecttopping file with layertree, map themes, variables and layouts.
+        And all the toppingfiles for styles, definition and layouttemplates.
+        """
         project, export_settings = self._make_project_and_export_settings()
         layers = project.layerTreeRoot().findLayers()
         self.assertEqual(len(layers), 10)
@@ -357,6 +389,59 @@ class ToppingMakerTest(unittest.TestCase):
         assert foundFrenchTheme
         assert foundRobotTheme
 
+        # check variables
+        variable_count = 0
+        foundFirstVariable = False
+        foundVariableWithStructure = False
+
+        with open(projecttopping_file_path, "r") as yamlfile:
+            projecttopping_data = yaml.safe_load(yamlfile)
+            assert "variables" in projecttopping_data
+            assert projecttopping_data["variables"]
+            for variable_key in projecttopping_data["variables"].keys():
+                if variable_key == "First Variable":
+                    assert (
+                        projecttopping_data["variables"][variable_key]
+                        == "This is a test value."
+                    )
+                    foundFirstVariable = True
+                if variable_key == "Variable with Structure":
+                    assert projecttopping_data["variables"][variable_key] == [
+                        "Not",
+                        "The",
+                        "Normal",
+                        815,
+                        "Case",
+                    ]
+                    foundVariableWithStructure = True
+                variable_count += 1
+
+        assert variable_count == 2
+        assert foundFirstVariable
+        assert foundVariableWithStructure
+
+        # check layouts
+        layout_count = 0
+        foundLayoutOne = False
+        foundLayoutThree = False
+
+        with open(projecttopping_file_path, "r") as yamlfile:
+            projecttopping_data = yaml.safe_load(yamlfile)
+            assert "layouts" in projecttopping_data
+            assert projecttopping_data["layouts"]
+            for layout_name in projecttopping_data["layouts"].keys():
+                if layout_name == "Layout One":
+                    assert "templatefile" in projecttopping_data["layouts"][layout_name]
+                    foundLayoutOne = True
+                if layout_name == "Layout Three":
+                    assert "templatefile" in projecttopping_data["layouts"][layout_name]
+                    foundLayoutThree = True
+                layout_count += 1
+
+        assert layout_count == 2
+        assert foundLayoutOne
+        assert foundLayoutThree
+
         # check toppingfiles
 
         # there should be exported 6 files (see _make_project_and_export_settings)
@@ -372,11 +457,12 @@ class ToppingMakerTest(unittest.TestCase):
 
         countchecked = 0
 
-        # there should be 13 toppingfiles:
+        # there should be 21 toppingfiles:
         # - one project topping
         # - 2 x 3 qlr files (two times since the layers are multiple times in the tree)
         # - 2 x 6 qml files (one layers with 3 styles, one layer with 2 styles and one layer with one style - and two times since the layers are multiple times in the tree)
-        assert len(target.toppingfileinfo_list) == 19
+        # - 2 qpt template files
+        assert len(target.toppingfileinfo_list) == 21
 
         for toppingfileinfo in target.toppingfileinfo_list:
             print(toppingfileinfo["path"])
@@ -428,8 +514,19 @@ class ToppingMakerTest(unittest.TestCase):
                 == "freddys_projects/this_specific_project/layerdefinition/freddys_layer_five.qlr"
             ):
                 countchecked += 1
+            if (
+                toppingfileinfo["path"]
+                == "freddys_projects/this_specific_project/layouttemplate/freddys_layout_one.qpt"
+            ):
+                countchecked += 1
+            if (
+                toppingfileinfo["path"]
+                == "freddys_projects/this_specific_project/layouttemplate/freddys_layout_three.qpt"
+            ):
+                countchecked += 1
 
-        assert countchecked == 18
+        # without the projecttopping file they are 20
+        assert countchecked == 20
 
     def test_custom_path_resolver(self):
         # load QGIS project into structure
@@ -479,6 +576,9 @@ class ToppingMakerTest(unittest.TestCase):
         assert countchecked == 6
 
     def _make_project_and_export_settings(self):
+        # ---
+        # make the project
+        # ---
         project = QgsProject()
         project.removeAllMapLayers()
 
@@ -542,7 +642,6 @@ class ToppingMakerTest(unittest.TestCase):
         allofemgroup.addLayer(l5)
 
         # create a map theme from the current state
-        # crashes on getting the model - check it out later dave
         # layertree_root = project.layerTreeRoot()
         # layertree_model = QgsLayerTreeModel(layertree_root)
         # map_theme_record = QgsMapThemeCollection.createThemeFromCurrentState(layertree_root,layertree_model)
@@ -588,6 +687,32 @@ class ToppingMakerTest(unittest.TestCase):
         map_theme_record.setExpandedGroupNodes(["Medium Group"])
         project.mapThemeCollection().insert("French Theme", map_theme_record)
 
+        # set the custom project variables
+        QgsExpressionContextUtils.setProjectVariable(
+            project, "First Variable", "This is a test value."
+        )
+        QgsExpressionContextUtils.setProjectVariable(project, "Another Variable", "2")
+        QgsExpressionContextUtils.setProjectVariable(
+            project, "Variable with Structure", ["Not", "The", "Normal", 815, "Case"]
+        )
+
+        # create layouts
+        layout = QgsPrintLayout(project)
+        layout.initializeDefaults()
+        layout.setName("Layout One")
+        project.layoutManager().addLayout(layout)
+        layout = QgsPrintLayout(project)
+        layout.initializeDefaults()
+        layout.setName("Layout Two")
+        project.layoutManager().addLayout(layout)
+        layout = QgsPrintLayout(project)
+        layout.initializeDefaults()
+        layout.setName("Layout Three")
+        project.layoutManager().addLayout(layout)
+
+        # ---
+        # and make the export settings
+        # ---
         export_settings = ExportSettings()
         export_settings.set_setting_values(
             ExportSettings.ToppingType.QMLSTYLE, None, "Layer One", True
@@ -644,8 +769,15 @@ class ToppingMakerTest(unittest.TestCase):
         export_settings.set_setting_values(
             ExportSettings.ToppingType.SOURCE, None, "Layer Three", True
         )
+
         # define the map themes to export
         export_settings.mapthemes = ["French Theme", "Robot Theme"]
+
+        # define the custom variables to export
+        export_settings.custom_variables = ["First Variable", "Variable with Structure"]
+
+        # define the layouts to export
+        export_settings.layouts = ["Layout One", "Layout Three"]
 
         print(f" Layer to style export: {export_settings.qmlstyle_setting_nodes}")
         print(

--- a/toppingmaker/exportsettings.py
+++ b/toppingmaker/exportsettings.py
@@ -67,7 +67,7 @@ class ExportSettings(object):
 
     # Custom Project Variables:
 
-    The custom variables to export are a simple list of the keys stored in `custom_variables`.
+    The custom variables to export are a simple list of the keys stored in `variables`.
 
     # Layouts:
 
@@ -88,7 +88,7 @@ class ExportSettings(object):
         # names of mapthemes to be exported
         self.mapthemes = []
         # keys of custom variables to be exported
-        self.custom_variables = []
+        self.variables = []
         # names of layouts
         self.layouts = []
 

--- a/toppingmaker/exportsettings.py
+++ b/toppingmaker/exportsettings.py
@@ -65,6 +65,14 @@ class ExportSettings(object):
 
     The map themes to export are a simple list of map theme names stored in `mapthemes`.
 
+    # Custom Project Variables:
+
+    The custom variables to export are a simple list of the keys stored in `custom_variables`.
+
+    # Layouts:
+
+    The print layouts to export are a simple list of layout names stored in `layouts`.
+
     """
 
     class ToppingType(Enum):
@@ -77,8 +85,12 @@ class ExportSettings(object):
         self.qmlstyle_setting_nodes = {}
         self.definition_setting_nodes = {}
         self.source_setting_nodes = {}
-        # list of mapthemes to be exported
+        # names of mapthemes to be exported
         self.mapthemes = []
+        # keys of custom variables to be exported
+        self.custom_variables = []
+        # names of layouts
+        self.layouts = []
 
     def set_setting_values(
         self,

--- a/toppingmaker/projecttopping.py
+++ b/toppingmaker/projecttopping.py
@@ -347,7 +347,7 @@ class ProjectTopping(QObject):
         ):
             self.clear()
 
-            maptheme_collection = QgsProject.instance().mapThemeCollection()
+            maptheme_collection = project.mapThemeCollection()
             for name in export_settings.mapthemes:
                 maptheme_item = {}
                 maptheme_record = maptheme_collection.mapThemeState(name)
@@ -396,14 +396,25 @@ class ProjectTopping(QObject):
         """
         root = project.layerTreeRoot()
         if root:
+            # make layertree
             self.layertree.make_item(project, project.layerTreeRoot(), export_settings)
+            self.stdout.emit(
+                self.tr("QGIS project layertree parsed with export settings."),
+                Qgis.Info,
+            )
+            # make layerorder
             layerorder_layers = (
                 root.customLayerOrder() if root.hasCustomLayerOrder() else []
             )
             if layerorder_layers:
                 self.layerorder = [layer.name() for layer in layerorder_layers]
+            self.stdout.emit(self.tr("QGIS project layerorder parsed."), Qgis.Info)
+            # make mapthemes
+            self.mapthemes.make_items(project, export_settings)
+
             self.stdout.emit(
-                self.tr("QGIS project parsed with export settings."), Qgis.Info
+                self.tr("QGIS project map themes parsed with export settings."),
+                Qgis.Info,
             )
         else:
             self.stdout.emit(

--- a/toppingmaker/projecttopping.py
+++ b/toppingmaker/projecttopping.py
@@ -401,17 +401,8 @@ class ProjectTopping(QObject):
     class Layouts(dict):
         """
         A dict object of dict items describing a layout with templatefile according to the layout names listed in the ExportSettings passed on parsing the QGIS project.
+        Such a dict item contains only one key at the moment: "templatefile"
         """
-
-        class LayoutItemProperties(object):
-            """
-            The properties of a layout item.
-            Currently it's only a layout  template file. Maybe in future here as well items or whatever can be defined.
-            """
-
-            def __init__(self):
-                # the layout  template file - if None then not requested
-                self.templatefile = None
 
         def __init__(self):
             self.temporary_toppingfile_dir = os.path.expanduser("~/.temp_topping_files")
@@ -426,7 +417,7 @@ class ProjectTopping(QObject):
             # go through all the print layouts in the project and export the requested ones
             for layout in project.layoutManager().printLayouts():
                 if layout.name() in export_settings.layouts:
-                    self[layout.name()] = ProjectTopping.Layouts.LayoutItemProperties()
+                    self[layout.name()] = {}
 
                     filename_slug = f"{slugify(layout.name())}.qpt"
                     os.makedirs(self.temporary_toppingfile_dir, exist_ok=True)
@@ -437,14 +428,15 @@ class ProjectTopping(QObject):
                     layout.saveAsTemplate(
                         temporary_toppingfile_path, QgsReadWriteContext()
                     )
-                    self[layout.name()].templatefile = temporary_toppingfile_path
+                    self[layout.name()]["templatefile"] = temporary_toppingfile_path
 
         def item_dict(self, target: Target):
             resolved_items = {}
             for layout_name in self.keys():
                 resolved_item = {}
                 resolved_item["templatefile"] = target.toppingfile_link(
-                    ProjectTopping.LAYOUTTEMPLATE_TYPE, self[layout_name].templatefile
+                    ProjectTopping.LAYOUTTEMPLATE_TYPE,
+                    self[layout_name]["templatefile"],
                 )
                 resolved_items[layout_name] = resolved_item
             return resolved_items

--- a/toppingmaker/projecttopping.py
+++ b/toppingmaker/projecttopping.py
@@ -48,9 +48,9 @@ class ProjectTopping(QObject):
     A project configuration resulting in a YAML file that contains:
     - layertree
     - layerorder
-    - project variables (future)
-    - print layout (future)
-    - map themes (future)
+    - map themes
+    - project variables
+    - print layouts
 
     QML style files, QLR layer definition files and the source of a layer can be linked in the YAML file and are exported to the specific folders.
     """

--- a/toppingmaker/projecttopping.py
+++ b/toppingmaker/projecttopping.py
@@ -393,7 +393,7 @@ class ProjectTopping(QObject):
             export_settings: ExportSettings,
         ):
             self.clear()
-            for variable_key in export_settings.custom_variables:
+            for variable_key in export_settings.variables:
                 self[variable_key] = QgsExpressionContextUtils.projectScope(
                     project
                 ).variable(variable_key)
@@ -439,7 +439,7 @@ class ProjectTopping(QObject):
                     )
                     self[layout.name()].templatefile = temporary_toppingfile_path
 
-        def items(self, target: Target):
+        def item_dict(self, target: Target):
             resolved_items = {}
             for layout_name in self.keys():
                 resolved_item = {}
@@ -454,7 +454,7 @@ class ProjectTopping(QObject):
         self.layertree = self.LayerTreeItem()
         self.mapthemes = self.MapThemes()
         self.layerorder = []
-        self.custom_variables = self.Variables()
+        self.variables = self.Variables()
         self.layouts = self.Layouts()
 
     def parse_project(
@@ -484,7 +484,7 @@ class ProjectTopping(QObject):
             # make mapthemes
             self.mapthemes.make_items(project, export_settings)
             # make variables
-            self.custom_variables.make_items(project, export_settings)
+            self.variables.make_items(project, export_settings)
             # make print layouts
             self.layouts.make_items(project, export_settings)
 
@@ -543,12 +543,15 @@ class ProjectTopping(QObject):
         """
         Gets the layertree as a list of dicts.
         Gets the layerorder as a list.
+        Gets the mapthemes as a dict.
+        Gets the variables as a dict.
+        Gets the layouts as a dict.
         And it generates and stores the toppingfiles according th the Target.
         """
         projecttopping_dict = {}
         projecttopping_dict["layertree"] = self.layertree.items_list(target)
         projecttopping_dict["mapthemes"] = dict(self.mapthemes)
-        projecttopping_dict["variables"] = dict(self.custom_variables)
-        projecttopping_dict["layouts"] = self.layouts.items(target)
+        projecttopping_dict["variables"] = dict(self.variables)
+        projecttopping_dict["layouts"] = self.layouts.item_dict(target)
         projecttopping_dict["layerorder"] = self.layerorder
         return projecttopping_dict


### PR DESCRIPTION
Parses MapThemes and Styles from the project. See kind of specification here https://github.com/opengisch/QgisModelBaker/issues/645#issuecomment-1300699081

**Thought:**
About storing the `ProjectTopping.mapthemes` in a dict vs. an object. Now it's an object inheriting a dict so it can parse the `project` with the `export_settings`.

**To Do:**
- [x] export_settings #9
- [x] map theme export
- [x] style export
- [x] test setup with export settings
- [x] tests
- [x] update README