### PR TITLE
Styles and MapThemes in `ExportSettings`

### DIFF
--- a/toppingmaker/exportsettings.py
+++ b/toppingmaker/exportsettings.py
@@ -119,7 +119,7 @@ class ExportSettings(object):
         setting = setting_nodes.get(key, {})
         if not setting:
             key = self._name_key(name, style)
-            setting = setting = setting_nodes.get(key, {})
+            setting = setting_nodes.get(key, {})
         return setting
 
     def _set_setting(

--- a/toppingmaker/exportsettings.py
+++ b/toppingmaker/exportsettings.py
@@ -80,30 +80,30 @@ class ExportSettings(object):
         name: str = None,
         export=True,
         categories=None,
-        style: str = None,
+        style_name: str = None,
     ) -> bool:
         """
         Appends the values (export, categories) to an existing setting
         """
         setting_nodes = self._setting_nodes(type)
-        setting = self._get_setting(setting_nodes, node, name, style)
+        setting = self._get_setting(setting_nodes, node, name, style_name)
         setting["export"] = export
         if categories:
             setting["categories"] = categories
-        return self._set_setting(setting_nodes, setting, node, name, style)
+        return self._set_setting(setting_nodes, setting, node, name, style_name)
 
     def get_setting(
         self,
         type: ToppingType,
         node: Union[QgsLayerTreeLayer, QgsLayerTreeGroup] = None,
         name: str = None,
-        style: str = None,
+        style_name: str = None,
     ) -> dict():
         """
         Returns an existing or an empty setting dict
         """
         setting_nodes = self._setting_nodes(type)
-        return self._get_setting(setting_nodes, node, name, style)
+        return self._get_setting(setting_nodes, node, name, style_name)
 
     def _setting_nodes(self, type: ToppingType):
         if type == ExportSettings.ToppingType.QMLSTYLE:
@@ -113,39 +113,39 @@ class ExportSettings(object):
         if type == ExportSettings.ToppingType.SOURCE:
             return self.source_setting_nodes
 
-    def _get_setting(self, setting_nodes, node=None, name=None, style=None):
+    def _get_setting(self, setting_nodes, node=None, name=None, style_name=None):
         # check for a setting according to the node if available and if no setting found, do it with the name.
-        key = self._node_key(node, style)
+        key = self._node_key(node, style_name)
         setting = setting_nodes.get(key, {})
         if not setting:
-            key = self._name_key(name, style)
+            key = self._name_key(name, style_name)
             setting = setting_nodes.get(key, {})
         return setting
 
     def _set_setting(
-        self, setting_nodes, setting, node=None, name=None, style=None
+        self, setting_nodes, setting, node=None, name=None, style_name=None
     ) -> bool:
         # get a key according to the node if available otherwise do it with the name.
-        key = self._node_key(node, style) or self._name_key(name, style)
+        key = self._node_key(node, style_name) or self._name_key(name, style_name)
         if key:
             setting_nodes[key] = setting
             return True
         return False
 
-    def _node_key(self, node=None, style=None):
+    def _node_key(self, node=None, style_name=None):
         # creates a key according to the available node.
         if node:
-            if style:
-                return (node.name(), style)
+            if style_name:
+                return (node.name(), style_name)
             else:
                 return node
         return None
 
-    def _name_key(self, name=None, style=None):
+    def _name_key(self, name=None, style_name=None):
         # creates a key according to the available name.
         if name:
-            if style:
-                return (name, style)
+            if style_name:
+                return (name, style_name)
             else:
                 return name
         return None

--- a/toppingmaker/exportsettings.py
+++ b/toppingmaker/exportsettings.py
@@ -66,9 +66,12 @@ class ExportSettings(object):
         SOURCE = 3
 
     def __init__(self):
+        # layertree settings
         self.qmlstyle_setting_nodes = {}
         self.definition_setting_nodes = {}
         self.source_setting_nodes = {}
+        # maptheme settings
+        self.mapthemes = []
 
     def set_setting_values(
         self,

--- a/toppingmaker/exportsettings.py
+++ b/toppingmaker/exportsettings.py
@@ -25,6 +25,8 @@ from qgis.core import QgsLayerTreeGroup, QgsLayerTreeLayer
 
 class ExportSettings(object):
     """
+    # Layertree:
+
     The requested export settings of each node in the specific dicts:
     - qmlstyle_setting_nodes
     - definition_setting_nodes
@@ -58,6 +60,11 @@ class ExportSettings(object):
         ("Node2","french"): { export: True, categories: <QgsMapLayer.StyleCategories> },
         ("Node2","robot"): { export: True, categories: <QgsMapLayer.StyleCategories> }
     }
+
+    # Mapthemes:
+
+    The map themes to export are a simple list of map theme names stored in `mapthemes`.
+
     """
 
     class ToppingType(Enum):
@@ -66,11 +73,11 @@ class ExportSettings(object):
         SOURCE = 3
 
     def __init__(self):
-        # layertree settings
+        # layertree settings per layer / group and type of export
         self.qmlstyle_setting_nodes = {}
         self.definition_setting_nodes = {}
         self.source_setting_nodes = {}
-        # maptheme settings
+        # list of mapthemes to be exported
         self.mapthemes = []
 
     def set_setting_values(

--- a/toppingmaker/exportsettings.py
+++ b/toppingmaker/exportsettings.py
@@ -114,26 +114,36 @@ class ExportSettings(object):
             return self.source_setting_nodes
 
     def _get_setting(self, setting_nodes, node=None, name=None, style=None):
-        key = self._key(node, name, style)
+        # check for a setting according to the node if available and if no setting found, do it with the name.
+        key = self._node_key(node, style)
         setting = setting_nodes.get(key, {})
+        if not setting:
+            key = self._name_key(name, style)
+            setting = setting = setting_nodes.get(key, {})
         return setting
 
     def _set_setting(
         self, setting_nodes, setting, node=None, name=None, style=None
     ) -> bool:
-        key = self._key(node, name, style)
+        # get a key according to the node if available otherwise do it with the name.
+        key = self._node_key(node, style) or self._name_key(name, style)
         if key:
             setting_nodes[key] = setting
             return True
         return False
 
-    def _key(self, node=None, name=None, style=None):
+    def _node_key(self, node=None, style=None):
+        # creates a key according to the available node.
         if node:
             if style:
                 return (node.name(), style)
             else:
                 return node
-        elif name:
+        return None
+
+    def _name_key(self, name=None, style=None):
+        # creates a key according to the available name.
+        if name:
             if style:
                 return (name, style)
             else:


### PR DESCRIPTION
The `ExportSettings` define in "what" needs to be exported "how":

The requested export settings of each node in the specific dicts:
- qmlstyle_setting_nodes
- definition_setting_nodes
- source_setting_nodes

The usual structure is using `QgsLayerTreeNode` as key and then export `True/False`:
```py
{
	<QgsLayerTreeNode(Node1)>: { export: False },
	<QgsLayerTreeNode(Node2)>: { export: True, styles: { "mono": export: True, categories: <QgsMapLayer.StyleCategories> } }
}
```

But alternatively the layername can be used as key. In `ProjectTopping` it first looks up the node and if not available looking up the name.

Using the node is much more consistent, since one can use layers with the same name, but for nodes you need the project already in advance.

With name you can use prepared settings to pass (before the project exists) e.g. in automated workflows.
```py
{
	"Node1": { export: False },
	"Node2": { export: True }
}
```

For some settings we have additional info. Like in `qmlstyle_nodes` `<QgsMapLayer.StyleCategories>`. These are Flags, and can be constructed manually as well.

```py
qmlstyle_nodes =
{
	<QgsLayerTreeNode(Node1)>: { export: False },
	<QgsLayerTreeNode(Node2)>: { export: True, categories: <QgsMapLayer.StyleCategories> }
}
```

## Styles

How do we store the **styles** now? Every style of a layer can have own category-settings. One possibilty would have been to nest it:

```py
{
	<QgsLayerTreeNode(Node1)>: { export: False },
	<QgsLayerTreeNode(Node2)>: { export: True, styles: { 
							"french": { 
								export: True, 
								categories: <QgsMapLayer.StyleCategories> 
								},
							"robot": { 
								export: True, 
								categories: <QgsMapLayer.StyleCategories> 
								} 
							}
}
```

With this we would have only one entry per node. But honestly, we want to have it simple because we are lazy with thinking and because flat is beautyful I suggest this way:

Using tuple as keys:
```py
{
	<QgsLayerTreeNode(Node2)>: { export: True },
	(<QgsLayerTreeNode(Node2)>,"french"): { export: True, categories: <QgsMapLayer.StyleCategories> },
	(<QgsLayerTreeNode(Node2)>,"robot"): { export: True, categories: <QgsMapLayer.StyleCategories> }
}
```

But this is not allowed. A tuple as a key cannot contain a mutable object. I did not try it but I guess it would give me an error: `unhashable type error`

So we would do it like this:
```py
{
	"Node1": { export: False },
        <QgsLayerTreeNode(Node2)>: { export: True, categories: <QgsMapLayer.StyleCategories> }
	("Node2","french"): { export: True, categories: <QgsMapLayer.StyleCategories> },
	("Node2","robot"): { export: True, categories: <QgsMapLayer.StyleCategories> }
}
```

Means on set / get we check if we have a style and a node (1) if not if we have a style and a name (2) if not if we have a node (3) if not if we have a name (4). And then we do:
1. make key-tuple from style and node.layer.name()
2. makekey-tuple from style and name
3. make key from node
4. make key from name


## MapThemes

For the map themes we only need a list of names. Maybe with adding another functionality it would make sense to change the names of the functions like from `set_setting_values` to `set_layertreenode_settings_values` but I wait for that until I continued with the other options that will come: project config, print layouts, variables and the GUI part...