### PR TITLE
Variables as toppings

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -6,13 +6,7 @@ with a database, so your own postgres installation is not affected at all.
 
 To run the tests, go to the main directory of the project and do
 
-```sh
-export QGIS_TEST_VERSION=latest # See https://hub.docker.com/r/qgis/qgis/tags/
-export GITHUB_WORKSPACE=$PWD # only for local execution
-docker run -v ${GITHUB_WORKSPACE}:/usr/src -w /usr/src opengisch/qgis:${QGIS_TEST_VERSION} sh -c 'xvfb-run pytest-3'
-```
-
 In one line, removing all containers.
 ```sh
-QGIS_TEST_VERSION=latest GITHUB_WORKSPACE=$PWD docker run -v ${GITHUB_WORKSPACE}:/usr/src -w /usr/src opengisch/qgis:${QGIS_TEST_VERSION} sh -c 'xvfb-run pytest-3'
+docker run -v $PWD:/usr/src -w /usr/src opengisch/qgis:latest sh -c 'xvfb-run pytest-3'
 ```

--- a/tests/test_toppingmaker.py
+++ b/tests/test_toppingmaker.py
@@ -703,6 +703,11 @@ class ToppingMakerTest(unittest.TestCase):
         QgsExpressionContextUtils.setProjectVariable(
             project, "Variable with Structure", ["Not", "The", "Normal", 815, "Case"]
         )
+        QgsExpressionContextUtils.setProjectVariable(
+            project,
+            "Path variable",
+            [os.path.join(self.projecttopping_test_path, "validconfig.ini")],
+        )
 
         # create layouts
         layout = QgsPrintLayout(project)
@@ -788,7 +793,12 @@ class ToppingMakerTest(unittest.TestCase):
         export_settings.mapthemes = ["French Theme", "Robot Theme"]
 
         # define the custom variables to export
-        export_settings.variables = ["First Variable", "Variable with Structure"]
+        export_settings.variables = [
+            "First Variable",
+            "Variable with Structure",
+            "Path variable",
+        ]
+        export_settings.path_variables = ["Path variable"]
 
         # define the layouts to export
         export_settings.layouts = ["Layout One", "Layout Three"]

--- a/tests/test_toppingmaker.py
+++ b/tests/test_toppingmaker.py
@@ -43,6 +43,9 @@ class ToppingMakerTest(unittest.TestCase):
     def setUpClass(cls):
         """Run before all tests."""
         cls.basetestpath = tempfile.mkdtemp()
+        cls.testdata_path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "testdata"
+        )
         cls.projecttopping_test_path = os.path.join(cls.basetestpath, "projecttopping")
 
     def test_target(self):
@@ -143,9 +146,11 @@ class ToppingMakerTest(unittest.TestCase):
         # check variables
         variables = project_topping.variables
         # Anyway in practice no spaces should be used to be able to access them in the expressions like @first_variable
-        assert variables.get("First Variable") == "This is a test value."
+        assert variables.get("First Variable")
+        assert variables.get("First Variable")["value"] == "This is a test value."
         # QGIS is currently (3.29) not able to store structures in the project file. Still...
-        assert variables.get("Variable with Structure") == [
+        assert variables.get("Variable with Structure")
+        assert variables.get("Variable with Structure")["value"] == [
             "Not",
             "The",
             "Normal",
@@ -416,11 +421,18 @@ class ToppingMakerTest(unittest.TestCase):
                         "Case",
                     ]
                     foundVariableWithStructure = True
+                if variable_key == "Validation Path Variable":
+                    assert (
+                        projecttopping_data["variables"][variable_key]
+                        == "freddys_projects/this_specific_project/generic/freddys_validConfig.ini"
+                    )
+                    foundVariableWithPath = True
                 variable_count += 1
 
-        assert variable_count == 2
+        assert variable_count == 3
         assert foundFirstVariable
         assert foundVariableWithStructure
+        assert foundVariableWithPath
 
         # check transaction mode
         with open(projecttopping_file_path) as yamlfile:
@@ -471,12 +483,13 @@ class ToppingMakerTest(unittest.TestCase):
 
         countchecked = 0
 
-        # there should be 21 toppingfiles:
+        # there should be 22 toppingfiles:
         # - one project topping
         # - 2 x 3 qlr files (two times since the layers are multiple times in the tree)
         # - 2 x 6 qml files (one layers with 3 styles, one layer with 2 styles and one layer with one style - and two times since the layers are multiple times in the tree)
         # - 2 qpt template files
-        assert len(target.toppingfileinfo_list) == 21
+        # - 1 generic file (validation.ini) what is created by variable
+        assert len(target.toppingfileinfo_list) == 22
 
         for toppingfileinfo in target.toppingfileinfo_list:
             self.print_info(toppingfileinfo["path"])
@@ -705,8 +718,8 @@ class ToppingMakerTest(unittest.TestCase):
         )
         QgsExpressionContextUtils.setProjectVariable(
             project,
-            "Path variable",
-            [os.path.join(self.projecttopping_test_path, "validconfig.ini")],
+            "Validation Path Variable",
+            os.path.join(self.testdata_path, "validConfig.ini"),
         )
 
         # create layouts
@@ -796,9 +809,10 @@ class ToppingMakerTest(unittest.TestCase):
         export_settings.variables = [
             "First Variable",
             "Variable with Structure",
-            "Path variable",
+            "Validation Path Variable",
         ]
-        export_settings.path_variables = ["Path variable"]
+        # content of this variable should be exported as toppingfile
+        export_settings.path_variables = ["Validation Path Variable"]
 
         # define the layouts to export
         export_settings.layouts = ["Layout One", "Layout Three"]

--- a/tests/testdata/validConfig.ini
+++ b/tests/testdata/validConfig.ini
@@ -1,0 +1,7 @@
+["PARAMETER"]
+validation="on"
+additionalModels="SH_ProjektdatenDB_Naturschutz_V1_0_AddChecks"
+
+["SH_ProjektdatenDB_Naturschutz_V1_0_AddChecks.SH_ProjektdatenDB_Naturschutz_V1_0_Validierung.v_Mitarbeitende.checkNameDuplikate"]
+multiplicity="on"
+type="on"

--- a/toppingmaker/exportsettings.py
+++ b/toppingmaker/exportsettings.py
@@ -88,6 +88,8 @@ class ExportSettings:
         self.mapthemes = []
         # keys of custom variables to be exported
         self.variables = []
+        # list of variable keys that are defined as paths and should be resolved
+        self.path_variables = []
         # names of layouts
         self.layouts = []
 

--- a/toppingmaker/projecttopping.py
+++ b/toppingmaker/projecttopping.py
@@ -435,11 +435,13 @@ class ProjectTopping(QObject):
 
                 # if it's defined as path variable, we have to expose it as toppingfile
                 if variable_key in export_settings.path_variables:
-                    os.makedirs(self.temporary_toppingfile_dir, exist_ok=True)
-                    temporary_toppingfile_path = os.path.join(
-                        self.temporary_toppingfile_dir, os.path.basename(variable_value)
-                    )
-                    variable_item["value"] = temporary_toppingfile_path
+                    path = variable_value
+                    if project.homePath() and not os.path.isabs(variable_value):
+                        # if it's a saved project and the path is not absolute, make it absolute
+                        path = os.path.join(
+                            variable_value, project.homePath(), variable_value
+                        )
+                    variable_item["value"] = path
                     variable_item["ispath"] = True
                 else:
                     variable_item["value"] = variable_value


### PR DESCRIPTION
When we pass `path_variables` to the `ExportSettings` we resolve those. Means we take the variable as file path, get the file, create a topping file from it and write into the variable a resolved path (in Model Baker Topping Exporter this will result in an ilidata key).
